### PR TITLE
Update FlowSensor.cpp

### DIFF
--- a/examples/YF-S201/Read_Flow_Rate/Read_Flow_Rate.ino
+++ b/examples/YF-S201/Read_Flow_Rate/Read_Flow_Rate.ino
@@ -17,7 +17,7 @@
 
 // pin -> interrupt pin
 FlowSensor Sensor(YFS201, D2);
-int timebefore = 0;
+unsigned long timebefore = 0; // Same type as millis()
 
 // Uncomment if use ESP8266 and ESP32
 // void IRAM_ATTR count()

--- a/examples/YF-S201/Read_Flow_Rate_and_Volume/Read_Flow_Rate_and_Volume.ino
+++ b/examples/YF-S201/Read_Flow_Rate_and_Volume/Read_Flow_Rate_and_Volume.ino
@@ -17,7 +17,7 @@
 
 // pin -> interrupt pin
 FlowSensor Sensor(YFS201, D2);
-int timebefore = 0;
+unsigned long timebefore = 0; // Same type as millis()
 
 // Uncomment if use ESP8266 and ESP32
 // void IRAM_ATTR count()

--- a/examples/YF-S201/Read_Volume/Read_Volume.ino
+++ b/examples/YF-S201/Read_Volume/Read_Volume.ino
@@ -17,7 +17,7 @@
 
 // pin -> interrupt pin
 FlowSensor Sensor(YFS201, D2);
-int timebefore = 0;
+unsigned long timebefore = 0; // same type as millis()
 
 // Uncomment if use ESP8266 and ESP32
 // void IRAM_ATTR count()

--- a/src/FlowSensor.cpp
+++ b/src/FlowSensor.cpp
@@ -75,7 +75,7 @@ void FlowSensor::begin(void (*userFunc)(void))
 {
   pinMode(this->_pin, INPUT);
   digitalWrite(this->_pin, INPUT_PULLUP); // Optional Internal Pull-Up
-  attachInterrupt(this->_pin, userFunc, RISING);
+  attachInterrupt(digitalPinToInterrupt(this->_pin), userFunc, RISING); // For better compatibility with any board, for example Arduino Leonardo Boards
 }
 
 /**


### PR DESCRIPTION
Hi Hafidhh
  I have tested your library on an Arduino Leonardo Board, more exactly and Arduino Things Uno Board based on Arduino Leonardo architecture, and interrupt has not been working.
  Researching for possible causes, i found that Interrupt Pin versus Interrupt Number, is not fixed on all boards, and arduino recommend to use the translation funcion   attachInterrupt(digitalPinToInterrupt(this->_pin) as mentionated here https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/

I tested now and is working!

I hope this can help other users.

Best Regards

@hugojorgemuller