### PR TITLE
Change data type to pulse to avoid overflow on 32767

### DIFF
--- a/src/FlowSensor.cpp
+++ b/src/FlowSensor.cpp
@@ -93,9 +93,9 @@ void FlowSensor::read(int calibration)
 /**
  * @brief 
  * 
- * @return int total pulse
+ * @return unsigned long totalpulse
  */
-int FlowSensor::getPulse()
+unsigned long FlowSensor::getPulse()
 {
   return this->_totalpulse;
 }

--- a/src/FlowSensor.h
+++ b/src/FlowSensor.h
@@ -24,8 +24,8 @@ class FlowSensor
 private:
   uint8_t _pin;
   uint8_t _type;
-  unsigned long _totalpulse;
-  unsigned long _pulse;
+  volatile unsigned long _totalpulse;
+  volatile unsigned long _pulse;
   float _pulse1liter;
   float _flowrateminute;
   float _flowratesecound;

--- a/src/FlowSensor.h
+++ b/src/FlowSensor.h
@@ -24,8 +24,8 @@ class FlowSensor
 private:
   uint8_t _pin;
   uint8_t _type;
-  int _totalpulse;
-  int _pulse;
+  unsigned long _totalpulse;
+  unsigned long _pulse;
   float _pulse1liter;
   float _flowrateminute;
   float _flowratesecound;
@@ -39,7 +39,7 @@ public:
   void begin(void (*userFunc)(void));
   void read(int calibration = 0);
   void count();
-  int getPulse();
+  unsigned long getPulse();
   float getFlowRate_m();
   float getFlowRate_s();
   float getVolume();


### PR DESCRIPTION
During the tests of the library measuring running water in a residence, it was found that the variable _totalpulse periodically took negative values.

I have made a change in the data types of the variables _pulse and _totalpulse, which were defined as "int" to type "unsigned long" to avoid overflow when reaching 32767. Now it is possible to measure up to 9.5 million liters (2^ 32-1=4E9, that is, 4294967295, which I divide by 450 pulses per liter, allows us to measure 4294967295/450=9.5444 million liters of water).