### PR TITLE
Changing Datatypes of _pulse and _totalpulse to avoid overflow

### DIFF
--- a/src/FlowSensor.cpp
+++ b/src/FlowSensor.cpp
@@ -103,9 +103,9 @@ void FlowSensor::read(int calibration)
 /**
  * @brief 
  * 
- * @return int total pulse
+ * @return unsigned long  _totalpulse
  */
-int FlowSensor::getPulse()
+unsigned long FlowSensor::getPulse()
 {
   return this->_totalpulse;
 }

--- a/src/FlowSensor.h
+++ b/src/FlowSensor.h
@@ -27,8 +27,8 @@ class FlowSensor
 private:
   uint8_t _pin;
   uint8_t _type;
-  volatile int _totalpulse;
-  volatile int _pulse;
+  volatile unsigned long _totalpulse;
+  volatile unsigned long _pulse;
   float _pulse1liter;
   float _flowrateminute;
   float _flowratesecound;
@@ -42,7 +42,7 @@ public:
   void begin(void (*userFunc)(void));
   void read(int calibration = 0);
   void count();
-  int getPulse();
+  unsigned long getPulse();
   float getFlowRate_m();
   float getFlowRate_s();
   float getVolume();


### PR DESCRIPTION
Hi Hafidhh
During the tests of the library measuring running water in a residence, it was found that the variable _totalpulse periodically took negative values due an overflow.
I have made a change in the data types of the variables _pulse and _totalpulse, which were defined as "int" to type "unsigned long" to avoid overflow when reaching 32767. Now it is possible to measure up to 9.5 million liters (2^ 32-1=4E9, that is, 4294967295, which I divide by 450 pulses per liter, allows us to measure 4294967295/450=9.5444 million liters of water).

I first made 3 commits on outdated fork, then cancell it, and re-sync my fork to library v1.1.0 and then submit commits again and ask for this Pull.

Regards

Hugo
