### PR TITLE
Added missing pointer in function read()

### DIFF
--- a/src/FlowSensor.cpp
+++ b/src/FlowSensor.cpp
@@ -52,7 +52,7 @@ void FlowSensor::count()
  */
 void FlowSensor::read(long calibration)
 {
-	this->_flowratesecound = (this->_pulse / (this->_pulse1liter + calibration)) / ((millis() - _timebefore) / 1000);
+	this->_flowratesecound = (this->_pulse / (this->_pulse1liter + calibration)) / ((millis() - this->_timebefore) / 1000);
 	this->_volume += (this->_pulse / (this->_pulse1liter + calibration));
 	this->_totalpulse += this->_pulse;
 	this->_pulse = 0;


### PR DESCRIPTION
# Description

Change the read function so that now _timebefore is called via a pointer. The "this->" was missing before.
It kind of produced some errors from time to time.

Fixes Issue #12 

## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

-Tested it via the same setup used to test the flowrate in the Setup described in Issue#12


**Test Configuration**:
* Firmware version : 
* IDE : Arduino (2.1.0) / PlatformIO (3.4.4)
* Hardware : Arduino Uno with the YF-S201 FlowSensor
* SDK : 
